### PR TITLE
Allow custom dialogues with the shell dialog behavior

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/Dialog.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/Dialog.cs
@@ -118,6 +118,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         protected abstract void SetTitleAndMessage();
 
         /// <summary>
+        /// Function to destroy the Dialog.
+        /// </summary>
+        public abstract void DismissDialog();
+
+        /// <summary>
         /// Instantiates a dialog and passes it a result
         /// </summary>
         /// <param name="dialogPrefab">Dialog prefab</param>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogButton.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// A reference to the Dialog that this button is on.
         /// </summary>
-        public DialogShell ParentDialog { get; set; }
+        public Dialog ParentDialog { get; set; }
 
         /// <summary>
         /// The type description of the button

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogShell.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogShell.cs
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Function to destroy the Dialog.
         /// </summary>
-        public void DismissDialog()
+        public override void DismissDialog()
         {
             State = DialogState.InputReceived;
         }


### PR DESCRIPTION
I wanted to build a custom dialog with the same behavior as the shell dialogs. I derived a class from the Dialog class and noticed that the DialogButtons need a DialogShell as parent. By changing the parent type to Dialog user can create their own dialogs but using the already existing logic for opening and closing (result) dialogs. Since the DialogButton originally calls the DismissDialog method in the DialogShell class, i added the abstract method to the Dialog base class. The changes should not break anything. It would be great if this could be integrated before the Dialog are graduated. 